### PR TITLE
Add categories template tag + Add filtering by categories in admin article list view

### DIFF
--- a/frozen.txt
+++ b/frozen.txt
@@ -1,19 +1,19 @@
-# Frozen requirement versions from '0.6.0' installation
-Django==4.1.9
+# Frozen requirement versions from '0.6.1' installation
+Django==4.2.5
 django-autocomplete-light==3.9.7
-django-ckeditor==6.5.1
-django-smart-media==0.2.2
-django-taggit==3.1.0
+django-ckeditor==6.7.0
+django-smart-media==0.3.1
+django-taggit==4.0.0
 django-view-breadcrumbs==2.4.1
-factory-boy==3.2.1
-flake8==6.0.0
+factory-boy==3.3.0
+flake8==6.1.0
 freezegun==1.2.2
 livereload==2.6.3
-Pillow==9.5.0
+Pillow==10.0.1
 pyquery==2.0.0
-pytest==7.3.1
+pytest==7.4.2
 pytest-django==4.5.2
 Sphinx==5.3.0
 sphinx-rtd-theme==1.1.0
-tox==4.5.1
+tox==4.11.3
 twine==4.0.2

--- a/lotus/admin/article.py
+++ b/lotus/admin/article.py
@@ -43,6 +43,7 @@ class ArticleAdmin(SmartModelAdmin):
         "pinned",
         "featured",
         "private",
+        "categories",
     )
     prepopulated_fields = {
         "slug": ("title",),

--- a/lotus/templates/templatetags/categories.html
+++ b/lotus/templates/templatetags/categories.html
@@ -1,0 +1,11 @@
+<div class="d-inline-flex ">
+    
+    {% for category in categories %}
+        <a  class="btn btn-sm btn-white rounded-3 mx-1 " style='
+        background-color:var(--{{ category.title|slugify }}bg,var(--bs-btn-bg));
+        color:var(--{{ category.title|slugify }}color,var(--bs-btn-color));
+        'href="{{ category.url }}">
+            {{ category.title }}
+        </a>
+    {% endfor %}
+</div>

--- a/lotus/templatetags/lotus.py
+++ b/lotus/templatetags/lotus.py
@@ -1,5 +1,6 @@
 from django.conf import settings
-from django.template import TemplateSyntaxError, Library, loader
+from django.template import Library, TemplateSyntaxError, loader
+from django.utils.translation import get_language
 
 from ..models import Article, Category
 
@@ -325,8 +326,7 @@ def check_object_lang_availability(context, source, **kwargs):
             given source that does not have this attribute.
 
     Returns:
-        dict: A dictionnary with summary informations of object language and its
-            availability.
+        dict: A dictionnary with summary informations of object language and its availability.
     """  # noqa: E501
     is_available = False
 
@@ -338,4 +338,56 @@ def check_object_lang_availability(context, source, **kwargs):
         "languages": settings.LANGUAGES,
         "language_keys": [k for k, v in settings.LANGUAGES],
         "language_labels": [v for k, v in settings.LANGUAGES],
+    }
+
+
+@register.inclusion_tag("templatetags/categories.html", name="news_categories")
+def article_categories():
+    """
+    Generates and returns a list of news categories based on the current language
+    setting.
+
+    This template tag retrieves the list of news categories that are available in the
+    user's current language. Each category in the list includes its title and a URL for
+    its detailed view.
+
+    Example:
+        This tag does not expect any argument: ::
+
+            {% load lotus %}
+            {% news_categories %}
+
+    Arguments:
+        None
+
+    Returns:
+        dict: A dictionary containing a list of dictionaries, each of which has the
+        `title` and `url` of a category.
+
+    Example return format:
+    : ::
+        {
+            "categories": [
+                {
+                    "title": "Category1",
+                    "url": "categories/category1_slug/"
+                },
+                {
+                    "title": "Category2",
+                    "url": "categories/category2_slug/"
+                }
+            ]
+        }
+    """
+    category_lang = get_language()
+    qs = Category.objects.get_for_lang(category_lang)
+
+    return {
+        "categories": [
+            {
+                "title": category.title,
+                "url": category.get_absolute_url()
+            }
+            for category in qs
+        ]
     }

--- a/tests/040_templatetags/045_categories.py
+++ b/tests/040_templatetags/045_categories.py
@@ -1,0 +1,95 @@
+import pytest
+
+from django.template import Context, Template
+from django.utils import translation
+
+from lotus.factories import CategoryFactory
+from lotus.templatetags.lotus import article_categories
+
+
+def assert_rendered_context(en_categories, rendered):
+    for category in en_categories:
+        assert {
+                "title": category.title,
+                "url": category.get_absolute_url()
+            } in rendered["categories"]
+
+
+def test_english_language(db):
+
+    with translation.override("en"):
+        en_categories = CategoryFactory.create_batch(3, language="en")
+        rendered = article_categories()
+
+        assert len(rendered["categories"]) == 3
+        assert_rendered_context(en_categories, rendered)
+
+
+def test_french_language(db):
+    with translation.override("fr"):
+        fr_categories = CategoryFactory.create_batch(3, language="fr")
+        rendered = article_categories()
+
+        assert len(rendered["categories"]) == 3
+        assert_rendered_context(fr_categories, rendered)
+
+
+def test_no_categories(db):
+    with translation.override("en"):
+        rendered = article_categories()
+
+        assert len(rendered["categories"]) == 0
+
+
+def test_multiple_languages(db):
+    en_categories = CategoryFactory.create_batch(3, language="en")
+    fr_categories = CategoryFactory.create_batch(3, language="fr")
+
+    with translation.override("en"):
+        rendered = article_categories()
+        assert len(rendered["categories"]) == 3
+        assert_rendered_context(en_categories, rendered)
+
+    with translation.override("fr"):
+        rendered = article_categories()
+        assert len(rendered["categories"]) == 3
+        assert_rendered_context(fr_categories, rendered)
+
+
+def test_unavailable_language(db):
+    CategoryFactory.create_batch(3, language="en")
+
+    # Set the language without categories
+    with translation.override("de"):
+        rendered = article_categories()
+        assert len(rendered["categories"]) == 0
+
+
+def test_categories_ordering(db):
+    en_categories = CategoryFactory.create_batch(5, language="en")
+
+    with translation.override("en"):
+        rendered = article_categories()
+        assert len(rendered["categories"]) == 5
+
+        rendered_titles = [category["title"] for category in rendered["categories"]]
+        original_titles = sorted([category.title for category in en_categories])
+
+        # Verify that the categories are ordered by title
+        assert rendered_titles == original_titles
+
+
+def test_template_rendering(db):
+    en_categories = CategoryFactory.create_batch(3, language="en")
+
+    with translation.override("en"):
+        categories = article_categories()
+        context = Context(categories)
+        template_to_render = Template(
+            "{% load lotus %}{% news_categories %}"
+        )
+        rendered_template = template_to_render.render(context)
+
+        for category in en_categories:
+            assert f'href="{category.get_absolute_url()}"' in rendered_template
+            assert category.title in rendered_template


### PR DESCRIPTION
Provide a templatetag that renders a tempate in which there is a formatted  list of news categories based on the current language setting.
Add filtering by categories in admin article list view.