### PR TITLE
[CHG] Improve migration doc

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -7,40 +7,38 @@ Migrations
 From 0.6.1 to 0.7.0
 *******************
 
-* If you were using a custom template for Article details and keeped the part for
-  related article listing that was starting with
-  ``{% with relateds=article_object.get_related %}`` you must change it to use the
-  new template tag which apply the publication and language filtering. See the
-  `current detail template <https://github.com/emencia/django-blog-lotus/blob/2774ca69af7d9acfa6dc77ac0bf7549bcd62779e/lotus/templates/lotus/article/detail.html#L169>`_
-  to know what to copy. This is important since the old template only applied language
-  filtering and totally ignore publication criterias;
-* You may now enable the API with installing package extra requirement ``api`` and
-  then follow install guide about :ref:`install_api`;
+* If you were using a custom template for Article details and retained the part for
+  the related article listing that began with
+  ``{% with relateds=article_object.get_related %}``, you must modify it to utilize 
+  the new template tag. This new tag applies both publication and language filtering.
+  Refer to the `current detail template <https://github.com/emencia/django-blog-lotus/blob/2774ca69af7d9acfa6dc77ac0bf7549bcd62779e/lotus/templates/lotus/article/detail.html#L169>`_
+  to determine what to copy. This modification is vital since the old template applied
+  only language filtering and completely disregarded publication criteria.
 
+* You can now activate the API by installing the extra package requirement ``api`` and
+then following the installation guide for :ref:`install_api`;
 
 From 0.6.0 to 0.6.1
 *******************
 
-Nothing to do, this is a minor maintenance release about documentation build on
-readthedocs.
-
+Nothing to do here, this is a minor maintenance release focused on documentation
+ build for readthedocs.
 
 From 0.5.2.1 to 0.6.0
 *********************
 
-* Upgrade ``django-autocomplete-light``;
-* Use the new template block names if you override some of lotus list or details
-  templates;
+* Upgrade ``django-autocomplete-light>=3.9.7``.
+  
+* Adjust to the new template block names if you have overridden any of Lotus's list or detail templates:
 
   * ``head_title`` to ``header-title``;
   * ``head_metas`` to ``metas``;
   * ``head_styles`` to ``header-resource``;
   * ``javascript`` to ``body-javascript``;
 
-* If you mounted Lotus on root url path and standing on removed ``articles/`` path to
-  not pollute root path, you need to mount Lotus on path like ``blog/`` or even
-  ``articles/``;
-* If you used Lotus for a single language site, now you may be able to disable
-  ``LocaleMiddleware``;
-* Now you are able to edit Lotus crumb titles for index views, see settings
-  documentation for ``LOTUS_CRUMBS_TITLES``;
+* If you had mounted Lotus on the root URL path and relied on the now-removed ``articles/``
+  path to avoid cluttering the root, you should remount Lotus on paths like ``blog/`` or ``articles/``.
+  
+* If you used Lotus for a single-language site, you might now have the option to disable ``LocaleMiddleware``.
+
+* You can now edit Lotus breadcrumb titles for index views. Consult the settings documentation for ``LOTUS_CRUMBS_TITLES``.


### PR DESCRIPTION
Also noted a common error across many cookiecutter based app, on `make install` execution:
```bash
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
sphinx-rtd-theme 1.1.0 requires docutils<0.18, but you have docutils 0.20.1 which is incompatible.
sphinx-rtd-theme 1.1.0 requires sphinx<6,>=1.6, but you have sphinx 7.2.6 which is incompatible.
```
